### PR TITLE
WIP: Add a basic openshift template based on the kubernetes configs

### DIFF
--- a/openshift.yml
+++ b/openshift.yml
@@ -1,0 +1,368 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: koding
+  annotations:
+    description: Koding
+    tags: "VCS"
+labels:
+  createdBy: "koding-template"
+parameters:
+  -
+    description: "The name for the application. The service will be named like the application."
+    displayName: "Application name"
+    name: APPLICATION_NAME
+    value: koding
+  -
+    description: "hostname for the public running instance"
+    displayName: "Hostname"
+    name: APPLICATION_HOSTNAME
+    required: true
+objects:
+  -
+    apiVersion: v1
+    kind: ReplicationController
+    metadata:
+      creationTimestamp: null
+      labels:
+        service: ${APPLICATION_NAME}-redis
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}-redis
+    spec:
+      replicas: 1
+      selector:
+        service: ${APPLICATION_NAME}-redis
+        app: ${APPLICATION_NAME}
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            service: ${APPLICATION_NAME}-redis
+            app: ${APPLICATION_NAME}
+        spec:
+          containers:
+          - image: redis
+            imagePullPolicy: ""
+            name: redis
+            ports:
+            - containerPort: 6379
+            resources: {}
+          restartPolicy: Always
+          serviceAccountName: ""
+          volumes: null
+    status:
+      replicas: 0
+  -
+    apiVersion: v1
+    kind: ReplicationController
+    metadata:
+      creationTimestamp: null
+      labels:
+        service: ${APPLICATION_NAME}-postgres
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}-postgres
+    spec:
+      replicas: 1
+      selector:
+        service: ${APPLICATION_NAME}-postgres
+        app: ${APPLICATION_NAME}
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            service: ${APPLICATION_NAME}-postgres
+            app: ${APPLICATION_NAME}
+        spec:
+          containers:
+          - image: koding/postgres:20160824
+            imagePullPolicy: ""
+            name: postgres
+            resources: {}
+          restartPolicy: Always
+          serviceAccountName: ""
+          volumes: null
+    status:
+      replicas: 0
+  -
+    apiVersion: v1
+    kind: ReplicationController
+    metadata:
+      creationTimestamp: null
+      labels:
+        service: ${APPLICATION_NAME}-mongo
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}-mongo
+    spec:
+      replicas: 1
+      selector:
+        service: ${APPLICATION_NAME}-mongo
+        app: ${APPLICATION_NAME}
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            service: ${APPLICATION_NAME}-mongo
+            app: ${APPLICATION_NAME}
+        spec:
+          containers:
+          - image: koding/mongo:20160906
+            imagePullPolicy: ""
+            name: mongo
+            args:
+            - "--dbpath"
+            - "/opt/db"
+            - "--smallfiles"
+            - "--nojournal"
+            resources: {}
+          restartPolicy: Always
+          serviceAccountName: ""
+          volumes: null
+    status:
+      replicas: 0
+  -
+    apiVersion: v1
+    kind: ReplicationController
+    metadata:
+      creationTimestamp: null
+      labels:
+        service: ${APPLICATION_NAME}-rabbitmq
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}-rabbitmq
+    spec:
+      replicas: 1
+      selector:
+        service: ${APPLICATION_NAME}-rabbitmq
+        app: ${APPLICATION_NAME}
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            service: ${APPLICATION_NAME}-rabbitmq
+            app: ${APPLICATION_NAME}
+        spec:
+          containers:
+          - image: rabbitmq:3-management
+            imagePullPolicy: ""
+            name: rabbitmq
+            resources: {}
+          restartPolicy: Always
+          serviceAccountName: ""
+          volumes: null
+    status:
+      replicas: 0
+  -
+    apiVersion: v1
+    kind: ReplicationController
+    metadata:
+      creationTimestamp: null
+      labels:
+        service: ${APPLICATION_NAME}
+        app: ${APPLICATION_NAME}
+      name: ${APPLICATION_NAME}
+    spec:
+      replicas: 1
+      selector:
+        service: ${APPLICATION_NAME}
+        app: ${APPLICATION_NAME}
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            service: ${APPLICATION_NAME}
+            app: ${APPLICATION_NAME}
+        spec:
+          containers:
+          - image: koding/koding:20160921
+            imagePullPolicy: ""
+            name: koding
+            args:
+            - "--version"
+            - "20160921"
+            - "--host"
+            - "${APPLICATION_HOSTNAME}:80"
+            - "--hostname"
+            - "${APPLICATION_HOSTNAME}"
+            - "--publicPort"
+            - "80"
+            ports:
+            - containerPort: 80
+            env:
+            - name: KODINGENV
+              value: default
+            - name: KONFIG_DOMAINS_PORT
+              value: "80"
+            - name: KONFIG_PUBLICPORT
+              value: "80"
+            - name: KONFIG_MONGO
+              value: "${APPLICATION_NAME}-mongo:27017/koding"
+            - name: KONFIG_MQ_HOST
+              value: "${APPLICATION_NAME}-rabbitmq"
+            - name: KONFIG_MQ_APIADDRESS
+              value: "${APPLICATION_NAME}-rabbitmq"
+            - name: KONFIG_REDIS_HOST
+              value: "${APPLICATION_NAME}-redis"
+            - name: KONFIG_REDIS_PORT
+              value: "6379"
+            - name: KONFIG_MONITORINGREDIS_HOST
+              value: "${APPLICATION_NAME}-redis"
+            - name: KONFIG_MONITORINGREDIS_PORT
+              value: "6379"
+            - name: KONFIG_POSTGRES_HOST
+              value: "${APPLICATION_NAME}-postgres"
+            - name: KONFIG_KONTROL_MONGOURL
+              value: "${APPLICATION_NAME}-mongo:27017/koding"
+            - name: KONFIG_KONTROL_POSTGRES_HOST
+              value: "${APPLICATION_NAME}-postgres"
+            - name: KONFIG_KLOUD_MONGOURL
+              value: "${APPLICATION_NAME}-mongo:27017/koding"
+            - name: KONFIG_SOCIALAPI_MONGO
+              value: "${APPLICATION_NAME}-mongo:27017/koding"
+            - name: KONFIG_SOCIALAPI_MQ_HOST
+              value: "${APPLICATION_NAME}-rabbitmq"
+            - name: KONFIG_SOCIALAPI_MQ_APIADDRESS
+              value: "${APPLICATION_NAME}-rabbitmq"
+            - name: KONFIG_SOCIALAPI_POSTGRES_HOST
+              value: "${APPLICATION_NAME}-postgres"
+            - name: KONFIG_SOCIALAPI_REDIS_URL
+              value: "${APPLICATION_NAME}-redis:6379"
+            - name: KONFIG_VMWATCHER_MONGO
+              value: "${APPLICATION_NAME}-mongo:27017/koding"
+            - name: KONFIG_VMWATCHER_REDIS
+              value: "${APPLICATION_NAME}-redis:6379"
+            resources: {}
+          restartPolicy: Always
+          serviceAccountName: ""
+          volumes: null
+    status:
+      replicas: 0
+  -
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      name: ${APPLICATION_NAME}-redis
+      labels:
+        app: ${APPLICATION_NAME}
+    spec:
+      ports:
+      - name: ""
+        port: 6379
+        protocol: ""
+        targetPort: 6379
+      type: ClusterIP
+      selector:
+        service: ${APPLICATION_NAME}-redis
+        app: ${APPLICATION_NAME}
+    status:
+      loadBalancer: {}
+  -
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      name: ${APPLICATION_NAME}-postgres
+      labels:
+        app: ${APPLICATION_NAME}
+    spec:
+      ports:
+      - name: ""
+        port: 5432
+        protocol: ""
+        targetPort: 5432
+      type: ClusterIP
+      selector:
+        service: ${APPLICATION_NAME}-postgres
+        app: ${APPLICATION_NAME}
+    status:
+      loadBalancer: {}
+  -
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      name: ${APPLICATION_NAME}-mongo
+      labels:
+        app: ${APPLICATION_NAME}
+    spec:
+      ports:
+      - name: ""
+        port: 27017
+        protocol: ""
+        targetPort: 27017
+      type: ClusterIP
+      selector:
+        service: ${APPLICATION_NAME}-mongo
+        app: ${APPLICATION_NAME}
+    status:
+      loadBalancer: {}
+  -
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      name: ${APPLICATION_NAME}-rabbitmq
+      labels:
+        app: ${APPLICATION_NAME}
+    spec:
+      ports:
+      - name: rabbitmq-main
+        port: 15672
+        protocol: TCP
+        targetPort: 15672
+      - name: rabbitmq-2
+        port: 5672
+        protocol: TCP
+        targetPort: 5672
+      - name: rabbitmq-3
+        port: 5671
+        protocol: TCP
+        targetPort: 5671
+      - name: rabbitmq-4
+        port: 15671
+        protocol: TCP
+        targetPort: 15671
+      - name: rabbitmq-5
+        port: 25672
+        protocol: TCP
+        targetPort: 25672
+      type: ClusterIP
+      selector:
+        service: ${APPLICATION_NAME}-rabbitmq
+        app: ${APPLICATION_NAME}
+    status:
+      loadBalancer: {}
+  -
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      name: ${APPLICATION_NAME}
+      labels:
+        app: ${APPLICATION_NAME}
+    spec:
+      ports:
+      - name: "80-http"
+        nodePort: 0
+        port: 80
+        protocol: ""
+        targetPort: 80
+      type: ClusterIP
+      selector:
+        service: ${APPLICATION_NAME}
+        app: ${APPLICATION_NAME}
+    status:
+      loadBalancer: {}
+  -
+    apiVersion: v1
+    kind: Route
+    metadata:
+      name: ${APPLICATION_NAME}
+      labels:
+        app: ${APPLICATION_NAME}
+    spec:
+      host: ${APPLICATION_HOSTNAME}
+      to:
+        kind: Service
+        name: ${APPLICATION_NAME}
+      port:
+        targetPort: 80-http


### PR DESCRIPTION
Adding as an MR into my own forks master just so I have some extra space to document it.

This is a basic OpenShift template that combines the kubernetes config from this repo.

The differences include:
- using a route instead of externalIPs for the koding service (I've been advised from OpenShift to wait until 1.4 for stable support of custom public ports using externalIPs)
- running the koding container, service and route all on port 80, as a restriction of OpenShift's default router
- hostname parameter available to be passed into the koding container
- very slight naming change, where each component is prefixed by the application name

Due to the fact that the OpenShift router doesn't support wildcard domain names yet: https://bugzilla.redhat.com/show_bug.cgi?id=1330947 

you currently have to manually add a route for each koding team that you create.

also missing is any form of persistence for now.
